### PR TITLE
New shop, add to readme, standardize names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
 # So. Cal. Craft Coffee Directory
 
 A list of good coffee and brewing recipes
+
+## About
+
+Socall.Coffee is a static site, built with [Jekyll](https://github.com/jekyll/jekyll).
+
+For more information about Jekyll, read up about its [Usage](https://jekyllrb.com/docs/usage/) and [Configuration](https://jekyllrb.com/docs/configuration/).
+
+## Getting Started
+
+### Requirements
+
+- [Ruby development environment](https://jekyllrb.com/docs/installation/)
+- Jekyll and [bundler](/docs/ruby-101/#bundler) [gems](/docs/ruby-101/#gems)
+  ```
+  gem install jekyll bundler
+  ```
+
+### Building for Local Development
+
+1. Fork and clone the repo
+1. Build the site and make it available on a local server
+
+   ```
+   bundle exec jekyll serve
+   ```
+
+1. Open up [http://localhost:8888](http://localhost:8888)
+
+If you encounter any unexpected errors during the above, please refer to the [troubleshooting](https://jekyllrb.com/docs/troubleshooting/#configuration-problems) page or the already-mentioned [requirements](https://jekyllrb.com/docs/installation/#requirements) page, as you might be missing development headers or other prerequisites.

--- a/_losangeles/commodity-coffee-shop.md
+++ b/_losangeles/commodity-coffee-shop.md
@@ -9,14 +9,13 @@ tags:
   - food
   - beer
 coffee:
-  - Heart Coffee Roasters
+  - Heart Coffee
   - St. Frank Coffee Roasters
   - Mad Cap Coffee Roasters
   - Methodical Coffee Roasters
   - Belleville Coffee Roasters
   - Parlor Coffee Roasters
-map: '33.783147,-118.153295'
-website: 'https://www.coffeeorwhatever.com/'
+map: "33.783147,-118.153295"
+website: "https://www.coffeeorwhatever.com/"
 featured_max_1: true
 ---
-

--- a/_losangeles/dayglow-coffee.md
+++ b/_losangeles/dayglow-coffee.md
@@ -7,15 +7,14 @@ type: Coffee Shop
 tags:
   - indoor seating
 coffee:
-  - Heart Coffee Roasters
+  - Heart Coffee
   - St. Frank Coffee Roasters
   - Mad Cap Coffee Roasters
   - Methodical Coffee Roasters
   - Belleville Coffee Roasters
   - Parlor Coffee Roasters
-map: '34.085563531674,-118.275099008793'
-website: 'https://dayglow.coffee/'
+map: "34.085563531674,-118.275099008793"
+website: "https://dayglow.coffee/"
 featured_max_1: false
 featured_min: false
 ---
-

--- a/_losangeles/eightfold-coffee.md
+++ b/_losangeles/eightfold-coffee.md
@@ -7,8 +7,7 @@ type: Coffee Shop
 tags:
   - Indoor Seating
 coffee:
-  - Heart Coffee Roasters
-map: '34.0710914418663,-118.250747892565'
+  - Heart Coffee
+map: "34.0710914418663,-118.250747892565"
 featured_max_1: true
 ---
-

--- a/_losangeles/espresso-cielo.md
+++ b/_losangeles/espresso-cielo.md
@@ -1,13 +1,12 @@
 ---
 title: Espresso Cielo
 tags:
-- Indoor Seating
+  - Indoor Seating
 shop_name: Espresso Cielo
 yelp_id: espresso-cielo-santa-monica
 website: http://sm.espressocielo.com
 type: Coffee Shop
 city: Santa Monica
 coffee:
-- Forty Ninth Parallel Coffee
+  - 49th Parallel
 ---
-

--- a/_losangeles/gb-coffee.md
+++ b/_losangeles/gb-coffee.md
@@ -1,20 +1,19 @@
 ---
 title: G&B Coffee
 tags:
-- Indoor Seating
-- Multi-roaster
+  - Indoor Seating
+  - Multi-roaster
 shop_name: G&B Coffee
 yelp_id: g-and-b-coffee-los-angeles-2
 website: http://gandbcoffee.com/
 type: Coffee Shop
 city: Downtown LA
 coffee:
-- George Howell Coffee
-- Heart Coffee
-- Ruby Colorful Coffees
-- Madcap Coffee
-- Ritual Coffee
-- Forty Ninth Parallel Coffee
+  - George Howell Coffee
+  - Heart Coffee
+  - Ruby Colorful Coffees
+  - Madcap Coffee
+  - Ritual Coffee
+  - 49th Parallel
 map: 34.0510953,-118.251598
 ---
-

--- a/_losangeles/gget-coffee.md
+++ b/_losangeles/gget-coffee.md
@@ -1,17 +1,16 @@
 ---
 title: Go Get Larchmont
 tags:
-- Indoor Seating
+  - Indoor Seating
 shop_name: Go Get Em Tiger Larchmont
 yelp_id: go-get-em-tiger-los-angeles
 website: http://ggetla.com
 type: Coffee Shop
 city: Central LA
 coffee:
-- Forty Ninth Parallel
-- George Howell Coffee
-- Heart Coffee
-- Various
+  - 49th Parallel
+  - George Howell Coffee
+  - Heart Coffee
+  - Various
 map: 34.075612,-118.3255138
 ---
-

--- a/_losangeles/offset-coffee.md
+++ b/_losangeles/offset-coffee.md
@@ -17,4 +17,5 @@ coffee:
   - Stumptown
   - Sweet Bloom
   - Toby's Estate
+map: 33.8035005,-118.3275883
 ---

--- a/_losangeles/offset-coffee.md
+++ b/_losangeles/offset-coffee.md
@@ -1,0 +1,20 @@
+---
+title: Offset Coffee
+tags:
+  - Indoor Seating
+  - Outdoor Seating
+shop_name: Offset Coffee
+yelp_id: offset-coffee-torrance
+website: https://offsetcoffee.com
+type: Coffee Shop
+city: Torrance
+coffee:
+  - 49th Parallel Roasters
+  - Camber
+  - Heart Coffee Roasters
+  - Madcap
+  - Onyx
+  - Stumptown
+  - Sweet Bloom
+  - Toby's Estate
+---

--- a/_losangeles/offset-coffee.md
+++ b/_losangeles/offset-coffee.md
@@ -9,9 +9,9 @@ website: https://offsetcoffee.com
 type: Coffee Shop
 city: Torrance
 coffee:
-  - 49th Parallel Roasters
+  - 49th Parallel
   - Camber
-  - Heart Coffee Roasters
+  - Heart Coffee
   - Madcap
   - Onyx
   - Stumptown

--- a/_losangeles/steelhead.md
+++ b/_losangeles/steelhead.md
@@ -7,10 +7,10 @@ website: http://steelheadcoffee.com/
 type: Coffee Shop
 city: Long Beach
 coffee:
-- Ruby Coffee Roasters
-- 49th Parallel Roasters
-- Heart Coffee Roasters
-- Huckleberry Roasters
-- Rose Park Roasters
+  - Ruby Coffee Roasters
+  - 49th Parallel
+  - Heart Coffee
+  - Huckleberry Roasters
+  - Rose Park Roasters
 map: 33.826417, -118.189171
 ---

--- a/_orange/bear-coast-coffee.md
+++ b/_orange/bear-coast-coffee.md
@@ -11,7 +11,7 @@ type: Coffee Shop
 city: San Clemente
 coffee:
 - Ritual Coffee
-- 49th Parallel Coffee
+- 49th Parallel
 - Heart Coffee
 yelp_id: bear-coast-coffee-san-clemente
 map: 33.4200861775673,-117.619638964534


### PR DESCRIPTION
- There's a new [shop in Torrance](https://www.yelp.com/biz_photos/offset-coffee-torrance)
- Heart Coffee and 49th Parallel were referred to in multiple ways (e.g. Forty-Ninth Parallel, Forty-Ninth Parallel Coffee, 49th Parallel Coffee Roasters) — now they're all consistent
- Added to Readme so future contributors can figure it out a little bit easier